### PR TITLE
Iss 8 enforce absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Copy the `example_cam.launch` and input another serial number to `serial_no` of 
 
 ### Image Saving
 
-`image_directory` - Directory used by the flag `save_disk` and `calib_mode` (**Note: Must be a valid directory, otherwise the camera fails to launch**)
+`image_directory` - Directory used by the flag `save_disk` and `calib_mode` (**Note: Must be a valid directory path with an ABSOLUTE path, otherwise the camera fails to launch or will not create the directory properly. **)
 
 `save_disk` - Save images to disk, under the directory `<image_directory>/stream` 
 

--- a/config/example_cam_config.yaml
+++ b/config/example_cam_config.yaml
@@ -2,8 +2,8 @@
 # General Configuration Parameters Go Here!
 ####################
 
-# directory to save images (make sure that directory exists!)
-image_directory: "~/"
+# directory to save images (make sure that directory exists and that it is an absolute path).
+image_directory: "/home/dev/"  # must be absolute path, not relative path (i.e. '~')
 
 # save images to the disk
 save_disk: false 


### PR DESCRIPTION
Completes #8 . It adds comments to ensure that the `image_directory` points to an absolute path instead of a relative one.