### PR TITLE
Added polling option for multiple cameras support

### DIFF
--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -154,7 +154,6 @@ class XimeaROSCam : public nodelet::Nodelet {
     // Bandwidth Limiting
     int cam_num_in_bus_;            // # cameras in a single bus
     float cam_bw_safetyratio_;        // ratio used based on a camera avail bw
-    int cam_detect_max_polls_;  // number of times camera is polled to open
 
     // Active variables
     bool is_active_;                // camera actively acquiring images?
@@ -164,6 +163,10 @@ class XimeaROSCam : public nodelet::Nodelet {
 
     // Output Messages
     bool publish_xi_get_image_;     // publish xiGetImage handle?
+
+    // Callback function for opening camera
+    ros::Timer xi_open_device_cb_;
+    void openDeviceCb();
 
     // Callback function for Camera Frame
     ros::Timer t_frame_cb_;

--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -154,6 +154,7 @@ class XimeaROSCam : public nodelet::Nodelet {
     // Bandwidth Limiting
     int cam_num_in_bus_;            // # cameras in a single bus
     float cam_bw_safetyratio_;        // ratio used based on a camera avail bw
+    int cam_detect_max_polls_;  // number of times camera is polled to open
 
     // Active variables
     bool is_active_;                // camera actively acquiring images?

--- a/launch/example_cam.launch
+++ b/launch/example_cam.launch
@@ -1,5 +1,6 @@
 <launch>
-    <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam" output="screen">
+    <node pkg="nodelet" type="nodelet" name="ximea_cam_manager" args="manager" output="screen" />
+    <node pkg="nodelet" type="nodelet" name="ximea_cam_1" args="load ximea_ros_cam/ximea_ros_cam ximea_cam_manager" output="screen">
         <param name="serial_no"       type="string" value="49605451" />
         <param name="cam_name"        type="string" value="ximea_cam" />
         <param name="calib_file"      type="string" value=""         />

--- a/launch/example_cam.launch
+++ b/launch/example_cam.launch
@@ -6,6 +6,7 @@
         <param name="frame_id"        type="string" value="0"        />
         <param name="num_cams_in_bus" type="int"    value="2"        />
         <param name="bw_safetyratio"  type="double" value="1.0"      />
+        <param name="cam_detect_max_polls" type="int" value="50"     />
         <param name="publish_xi_get_image" type="bool" value="false"/>
         <rosparam command="load" file="$(find ximea_ros_cam)/config/example_cam_config.yaml" />
     </node>

--- a/launch/example_cam.launch
+++ b/launch/example_cam.launch
@@ -6,7 +6,6 @@
         <param name="frame_id"        type="string" value="0"        />
         <param name="num_cams_in_bus" type="int"    value="2"        />
         <param name="bw_safetyratio"  type="double" value="1.0"      />
-        <param name="cam_detect_max_polls" type="int" value="50"     />
         <param name="publish_xi_get_image" type="bool" value="false"/>
         <rosparam command="load" file="$(find ximea_ros_cam)/config/example_cam_config.yaml" />
     </node>

--- a/src/ximea_ros_cam.cpp
+++ b/src/ximea_ros_cam.cpp
@@ -64,7 +64,6 @@ XimeaROSCam::~XimeaROSCam() {
         this->xi_h_ = NULL;
     }
     NODELET_INFO("Ximea camera stopped");
-    ros::Duration(1).sleep();
 
     // To avoid warnings
     (void)xi_stat;
@@ -81,7 +80,7 @@ void XimeaROSCam::onInit() {
 
     // Camera initialization
     this->initCam();
-    this->xi_open_device_cb_ = this->private_nh_.createTimer(ros::Duration(1),
+    this->xi_open_device_cb_ = this->private_nh_.createTimer(ros::Duration(2),
         boost::bind(&XimeaROSCam::openDeviceCb, this));
 
     // Publishers and Subscriptions
@@ -545,12 +544,9 @@ void XimeaROSCam::openCam() {
 
 void XimeaROSCam::openDeviceCb() {
   XI_RETURN xi_stat;
-  DWORD tmp;
-  int num;
+
   // Disable auto bandwidth calculation (before camera open)
   // Do this if bandwidth limitation is required or desired
-  num = xiGetNumberDevices(&tmp);
-
   if (this->cam_num_in_bus_ > 1) {
       xiSetParamInt(0, XI_PRM_AUTO_BANDWIDTH_CALCULATION, XI_OFF);
   }
@@ -558,11 +554,14 @@ void XimeaROSCam::openDeviceCb() {
   xi_stat = xiOpenDeviceBy(XI_OPEN_BY_SN,
                            this->cam_serialno_.c_str(),
                            &this->xi_h_);
-  ROS_INFO_STREAM("Polling cam_serialno " << this->cam_serialno_ << " " << xi_stat << " " << num);
+  ROS_INFO_STREAM("Polling cam_serialno " << this->cam_serialno_);
   if (this->xi_h_ != NULL) {
     this->xi_open_device_cb_.stop();
     XimeaROSCam::openCam();
   }
+
+  // To avoid warnings
+  (void)xi_stat;
 }
 
 // Start aquiring data

--- a/src/ximea_ros_cam.cpp
+++ b/src/ximea_ros_cam.cpp
@@ -52,6 +52,7 @@ XimeaROSCam::~XimeaROSCam() {
     // Init variables
     XI_RETURN xi_stat;
 
+    NODELET_INFO("Shutting down Ximea camera");
     // Stop acquisition and close device if handle is available
     if (this->xi_h_ != NULL) {
         // Stop image acquisition
@@ -62,6 +63,8 @@ XimeaROSCam::~XimeaROSCam() {
         xiCloseDevice(this->xi_h_);
         this->xi_h_ = NULL;
     }
+    NODELET_INFO("Ximea camera stopped");
+    ros::Duration(1).sleep();
 
     // To avoid warnings
     (void)xi_stat;
@@ -78,7 +81,7 @@ void XimeaROSCam::onInit() {
 
     // Camera initialization
     this->initCam();
-    this->xi_open_device_cb_ = this->private_nh_.createTimer(ros::Duration(3),
+    this->xi_open_device_cb_ = this->private_nh_.createTimer(ros::Duration(1),
         boost::bind(&XimeaROSCam::openDeviceCb, this));
 
     // Publishers and Subscriptions
@@ -546,11 +549,11 @@ void XimeaROSCam::openDeviceCb() {
   int num;
   // Disable auto bandwidth calculation (before camera open)
   // Do this if bandwidth limitation is required or desired
+  num = xiGetNumberDevices(&tmp);
+
   if (this->cam_num_in_bus_ > 1) {
       xiSetParamInt(0, XI_PRM_AUTO_BANDWIDTH_CALCULATION, XI_OFF);
   }
-
-  //num = xiGetNumberDevices(&tmp);
 
   xi_stat = xiOpenDeviceBy(XI_OPEN_BY_SN,
                            this->cam_serialno_.c_str(),


### PR DESCRIPTION
Fixed the issue of multiple cameras being launched from the same file by introducing a polling feature. Now, each node instance polls the Ximea API until it finds its specified camera. Fixes #10.

@carloswanguw 