### PR TITLE
if camera info can not be loaded, doesn't publish anything

### DIFF
--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -107,6 +107,7 @@ class XimeaROSCam : public nodelet::Nodelet {
     // Inactive variables
     ros::Publisher cam_img_counter_pub_;     // Image counter
     uint32_t img_count_;                     // Image count
+    bool cam_info_loaded_;                    // is camera info loaded?
     boost::shared_ptr<camera_info_manager::CameraInfoManager>
                         cam_info_manager_;   // Cam info manager handle
     ros::Publisher cam_info_pub_;             // Cam info publisher handle


### PR DESCRIPTION
If camera info can not be loaded, it doesn't publish anything an sets an internal flag `cam_info_loaded_` to be false.