### PR TITLE
Multiple camera launch

### DIFF
--- a/config/example_cam_config.yaml
+++ b/config/example_cam_config.yaml
@@ -25,7 +25,7 @@ format: "XI_RGB24"
 
 # triggering (0 - none, 1 - software trigger (NOT IMPLMENTED YET),
 # 2 - hardware trigger)
-cam_trigger_mode: 2
+cam_trigger_mode: 0
 hw_trigger_edge: 0            # if hw trigger, 0/1 = rising/falling edge trigger
 
 # for camera frame rate
@@ -36,7 +36,7 @@ img_capture_timeout: 1000     # timeout in milliseconds for xiGetImage()
 
 # exposure settings
 auto_exposure: false          # auto exposure on or off
-exposure_time: 1000           # manual exposure time in microseconds
+exposure_time: 6000           # manual exposure time in microseconds
 manual_gain: 9                # manual exposure gain
 auto_exposure_priority: 0.8   # auto exposure to gain ratio (1 = use only exposure)
 auto_time_limit: 30000        # auto exposure time limit in microseconds

--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -166,6 +166,9 @@ class XimeaROSCam : public nodelet::Nodelet {
     bool publish_xi_image_info_;     // publish xiGetImage handle?
 
     // Callback function for Camera Frame
+    ros::Timer xi_open_device_cb_;
+    void openDeviceCb();
+
     ros::Timer t_frame_cb_;
     void frameCaptureCb();
 

--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -126,6 +126,7 @@ class XimeaROSCam : public nodelet::Nodelet {
     int cam_bytesperpixel_;                  // Camera image bytes per pixel
     std::string cam_serialno_;               // Camera serial no
     std::string cam_frameid_;
+    float poll_time_;			     // For launching cameras in succession
     int cam_model_;
     std::string cam_calib_file_;
     int cam_trigger_mode_;

--- a/launch/example_cam.launch
+++ b/launch/example_cam.launch
@@ -7,6 +7,7 @@
         <param name="num_cams_in_bus" type="int"    value="2"        />
         <param name="bw_safetyratio"  type="double" value="1.0"      />
         <param name="publish_xi_image_info" type="bool" value="false"/>
+        <param name="poll_time"       type="double" value="2.0"/>
         <rosparam command="load" file="$(find ximea_ros_cam)/config/example_cam_config.yaml" />
     </node>
 </launch>

--- a/launch/example_cam.launch
+++ b/launch/example_cam.launch
@@ -1,6 +1,6 @@
 <launch>
     <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam" output="screen">
-        <param name="serial_no"       type="string" value="49605451" />
+        <param name="serial_no"       type="string" value="12345678" />
         <param name="cam_name"        type="string" value="ximea_cam" />
         <param name="calib_file"      type="string" value=""         />
         <param name="frame_id"        type="string" value="0"        />

--- a/launch/multiple_cams.launch
+++ b/launch/multiple_cams.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam_2" output="screen">
+    <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam_1" output="screen">
         <param name="serial_no"       type="string" value="12345678" />
         <param name="cam_name"        type="string" value="ximea_cam" />
         <param name="calib_file"      type="string" value=""         />
@@ -7,10 +7,11 @@
         <param name="num_cams_in_bus" type="int"    value="2"        />
         <param name="bw_safetyratio"  type="double" value="1.0"      />
         <param name="publish_xi_image_info" type="bool" value="false"/>
+        <param name="poll_time"       type="double" value="2.0"/>
         <rosparam command="load" file="$(find ximea_ros_cam)/config/example_cam_config.yaml" />
     </node>
 
-    <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam_1" output="screen">
+    <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam_2" output="screen">
         <param name="serial_no"       type="string" value="87654321" />
         <param name="cam_name"        type="string" value="ximea_cam" />
         <param name="calib_file"      type="string" value=""         />
@@ -18,6 +19,7 @@
         <param name="num_cams_in_bus" type="int"    value="2"        />
         <param name="bw_safetyratio"  type="double" value="1.0"      />
         <param name="publish_xi_image_info" type="bool" value="false"/>
+        <param name="poll_time"       type="double" value="4.0"/>
         <rosparam command="load" file="$(find ximea_ros_cam)/config/example_cam_config.yaml" />
     </node>
 </launch>

--- a/launch/multiple_cams.launch
+++ b/launch/multiple_cams.launch
@@ -1,0 +1,23 @@
+<launch>
+    <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam_2" output="screen">
+        <param name="serial_no"       type="string" value="12345678" />
+        <param name="cam_name"        type="string" value="ximea_cam" />
+        <param name="calib_file"      type="string" value=""         />
+        <param name="frame_id"        type="string" value="0"        />
+        <param name="num_cams_in_bus" type="int"    value="2"        />
+        <param name="bw_safetyratio"  type="double" value="1.0"      />
+        <param name="publish_xi_image_info" type="bool" value="false"/>
+        <rosparam command="load" file="$(find ximea_ros_cam)/config/example_cam_config.yaml" />
+    </node>
+
+    <node pkg="ximea_ros_cam" type="ximea_ros_cam_node" name="ximea_cam_1" output="screen">
+        <param name="serial_no"       type="string" value="87654321" />
+        <param name="cam_name"        type="string" value="ximea_cam" />
+        <param name="calib_file"      type="string" value=""         />
+        <param name="frame_id"        type="string" value="0"        />
+        <param name="num_cams_in_bus" type="int"    value="2"        />
+        <param name="bw_safetyratio"  type="double" value="1.0"      />
+        <param name="publish_xi_image_info" type="bool" value="false"/>
+        <rosparam command="load" file="$(find ximea_ros_cam)/config/example_cam_config.yaml" />
+    </node>
+</launch>

--- a/src/ximea_ros_cam.cpp
+++ b/src/ximea_ros_cam.cpp
@@ -137,8 +137,9 @@ void XimeaROSCam::initTimers() {
     // Report start of function
     ROS_INFO("Loading Timers ... ");
 
-    // Load camera polling callback timer
-    this->xi_open_device_cb_ = this->private_nh_.createTimer(ros::Duration(2), 
+    // Load camera polling callback timer ((Ensure that with multiple cameras, 
+    // each time is about 2 seconds spaced apart)
+    this->xi_open_device_cb_ = this->private_nh_.createTimer(ros::Duration(this->poll_time_), 
         boost::bind(&XimeaROSCam::openDeviceCb, this));
 
     // Load camera frame capture callback timer
@@ -213,6 +214,8 @@ void XimeaROSCam::initCam() {
     this->private_nh_.param( "calib_file", this->cam_calib_file_,
         std::string("INVALID"));
     ROS_INFO_STREAM("calibration file: " << this->cam_calib_file_);
+    this->private_nh_.param("poll_time", this->poll_time_, -1.0f);
+    ROS_INFO_STREAM("poll_time_: " << this->poll_time_);
 
     //      -- apply compressed image parameters (from image_transport) --
     this->private_nh_.param( "image_transport_compressed_format",
@@ -581,7 +584,7 @@ void XimeaROSCam::openDeviceCb() {
             this->cam_serialno_.c_str(),
             &this->xi_h_);
 
-    if (this->xi_h_ != NULL) {
+    if (xi_stat == XI_OK && this->xi_h_ != NULL) {
         ROS_INFO_STREAM("Poll successful. Loading serial #: "
                         << this->cam_serialno_);
         this->xi_open_device_cb_.stop();


### PR DESCRIPTION
Continuation of https://github.com/wavelab/ximea_ros_cam/pull/11. Addresses #10 

The only way to truly get this to work is to ensure that each camera is launched about 2 seconds apart from one another, here we set the `poll_time` from the launch files to be 2 seconds apart.