### PR TITLE
Add topic diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(catkin_deps
     camera_info_manager
     std_msgs
     message_generation
+    diagnostic_updater
 )
 
 find_package(catkin REQUIRED ${catkin_deps})

--- a/config/example_cam_config.yaml
+++ b/config/example_cam_config.yaml
@@ -6,7 +6,7 @@
 image_directory: "/home/dev/"  # must be absolute path, not relative path (i.e. '~')
 
 # save images to the disk
-save_disk: false 
+save_disk: false
 
 # save images on trigger (calibration only)
 calib_mode: false
@@ -16,8 +16,9 @@ calib_mode: false
 ####################
 
 enable_diagnostics: true
-frequency_tolerance: 1.0
 data_age_max: 0.1
+pub_frequency: 10.0
+pub_frequency_tolerance: 1.0
 
 ####################
 # Camera Configuration Parameters Go Here!

--- a/config/example_cam_config.yaml
+++ b/config/example_cam_config.yaml
@@ -12,6 +12,14 @@ save_disk: false
 calib_mode: false
 
 ####################
+# Diagnostics Configuration Parameters Go Here!
+####################
+
+enable_diagnostics: true
+frequency_tolerance: 1.0
+data_age_max: 0.1
+
+####################
 # Camera Configuration Parameters Go Here!
 ####################
 

--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -6,6 +6,8 @@
 #include <ros/ros.h>
 #include <nodelet/nodelet.h>
 #include <pluginlib/class_list_macros.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <diagnostic_updater/publisher.h>
 
 //      XIMEA CAMERA INCLUDES
 #include <m3api/xiApi.h>
@@ -68,16 +70,23 @@ class XimeaROSCam : public nodelet::Nodelet {
     void initNodeHandles();
 
     /**
+     * @brief  Initialize diagnostics.
+     *
+     * Initialize diagnostics and its parameters.
+     */
+    void initDiagnostics();
+
+    /**
      * @brief  Initialize all publishers.
      *
-     * Initialize all publishers. Includes the system supervisor publisher.
+     * Initialize all publishers.
      */
     void initPubs();
 
     /**
      * @brief  Initialize all timers.
      *
-     * Initialize all timers. Includes the system supervisor publisher.
+     * Initialize all timers.
      */
     void initTimers();
 
@@ -145,13 +154,22 @@ class XimeaROSCam : public nodelet::Nodelet {
     int cam_roi_height_;
     bool cam_framerate_control_;   // framerate control - enable or disable
     int cam_framerate_set_;      // framerate control - setting fps
-
     int cam_img_cap_timeout_;       // max time to wait for img
     // white balance mode: 0 - none, 1 - use coeffs, 2 = auto
     int cam_white_balance_mode_;
     float cam_white_balance_coef_r_; // white balance coefficient (rgb)
     float cam_white_balance_coef_g_;
     float cam_white_balance_coef_b_;
+
+    // Diagnostics
+    bool enable_diagnostics;
+    diagnostic_updater::Updater diag_updater;
+    std::shared_ptr<diagnostic_updater::TopicDiagnostic> cam_pub_diag;
+    double frequency_min;
+    double frequency_max;
+    double frequency_tolerance;
+    double age_min;
+    double age_max;
 
     // Bandwidth Limiting
     int cam_num_in_bus_;            // # cameras in a single bus

--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -165,7 +165,8 @@ class XimeaROSCam : public nodelet::Nodelet {
     bool enable_diagnostics;
     diagnostic_updater::Updater diag_updater;
     std::shared_ptr<diagnostic_updater::TopicDiagnostic> cam_pub_diag;
-    double frequency_tolerance;
+    double pub_frequency_tolerance;
+    double pub_frequency;
     double frequency_min;
     double frequency_max;
     double age_min;

--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -165,9 +165,9 @@ class XimeaROSCam : public nodelet::Nodelet {
     bool enable_diagnostics;
     diagnostic_updater::Updater diag_updater;
     std::shared_ptr<diagnostic_updater::TopicDiagnostic> cam_pub_diag;
+    double frequency_tolerance;
     double frequency_min;
     double frequency_max;
-    double frequency_tolerance;
     double age_min;
     double age_max;
 

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
     <depend>std_msgs</depend>
     <depend>opencv3</depend>
     <depend>message_generation</depend>
+    <depend>diagnostic_updater</depend>
 
     <!-- The export tag contains other, unspecified, tags -->
     <export>

--- a/src/ximea_ros_cam.cpp
+++ b/src/ximea_ros_cam.cpp
@@ -116,8 +116,10 @@ void XimeaROSCam::initNodeHandles() {
 
 void XimeaROSCam::initDiagnostics() {
     if (this->enable_diagnostics) {
-        this->frequency_min = this->cam_framerate_set_ - this->frequency_tolerance;
-        this->frequency_max = this->cam_framerate_set_ + this->frequency_tolerance;
+        this->frequency_min =
+            this->pub_frequency - this->pub_frequency_tolerance;
+        this->frequency_max =
+            this->pub_frequency + this->pub_frequency_tolerance;
         this->diag_updater.setHardwareID(this->cam_name_);
         this->cam_pub_diag =
             std::make_shared<diagnostic_updater::TopicDiagnostic>(
@@ -125,7 +127,7 @@ void XimeaROSCam::initDiagnostics() {
                 this->diag_updater,
                 diagnostic_updater::FrequencyStatusParam(
                     &this->frequency_min, &this->frequency_max,
-                    0.0, 10),
+                    0.0, 20),
                 diagnostic_updater::TimeStampStatusParam(
                     this->age_min, this->age_max));
     }
@@ -238,10 +240,16 @@ void XimeaROSCam::initCam() {
     ROS_INFO_STREAM("calibration file: " << this->cam_calib_file_);
     this->private_nh_.param("poll_time", this->poll_time_, -1.0f);
     ROS_INFO_STREAM("poll_time_: " << this->poll_time_);
-    this->private_nh_.param("enable_diagnostics", this->enable_diagnostics, false);
-    ROS_INFO_STREAM("frequency_tolerance: " << this->frequency_tolerance);
-    this->private_nh_.param("frequency_tolerance", this->frequency_tolerance, 1.0);
+
+    // Diagnostics
+    this->private_nh_.param("enable_diagnostics", this->enable_diagnostics,
+        false);
     ROS_INFO_STREAM("enable_diagnostics: " << this->enable_diagnostics);
+    this->private_nh_.param("pub_frequency", this->pub_frequency, 1.0);
+    ROS_INFO_STREAM("pub_frequency: " << this->pub_frequency);
+    this->private_nh_.param("pub_frequency_tolerance",
+        this->pub_frequency_tolerance, 1.0);
+    ROS_INFO_STREAM("pub_frequency_tolerance: " << this->pub_frequency_tolerance);
     this->private_nh_.param("data_age_max", this->age_max, 0.1);
     ROS_INFO_STREAM("data_age_max: " << this->age_max);
 

--- a/src/ximea_ros_cam.cpp
+++ b/src/ximea_ros_cam.cpp
@@ -247,9 +247,9 @@ void XimeaROSCam::initCam() {
 
     // Diagnostics
     this->private_nh_.param("enable_diagnostics", this->enable_diagnostics,
-        false);
+        true);
     ROS_INFO_STREAM("enable_diagnostics: " << this->enable_diagnostics);
-    this->private_nh_.param("pub_frequency", this->pub_frequency, 1.0);
+    this->private_nh_.param("pub_frequency", this->pub_frequency, 10.0);
     ROS_INFO_STREAM("pub_frequency: " << this->pub_frequency);
     this->private_nh_.param("pub_frequency_tolerance",
         this->pub_frequency_tolerance, 1.0);

--- a/src/ximea_ros_cam.cpp
+++ b/src/ximea_ros_cam.cpp
@@ -39,7 +39,7 @@ std::map<std::string, std::string> XimeaROSCam::ImgEncodingMap = {
 std::map<int, int> XimeaROSCam::CamMaxPixelWidth = { {0, 1280} };
 std::map<int, int> XimeaROSCam::CamMaxPixelHeight = { {0, 1024} };
 
-XimeaROSCam::XimeaROSCam() {
+XimeaROSCam::XimeaROSCam() : diag_updater{} {
     this->img_count_ = 0;                   // assume 0 images published
     this->cam_framerate_control_ = false;
     this->cam_white_balance_mode_ = 0;
@@ -47,6 +47,13 @@ XimeaROSCam::XimeaROSCam() {
     this->is_active_ = false;
     this->xi_h_ = NULL;
     this->cam_info_loaded_ = false;
+
+    // TODO: Revise/relocate these n
+    this->frequency_min = 9.0;
+    this->frequency_max = 11.0;
+    this->frequency_tolerance = 0.0;
+    this->age_min = 0.0;
+    this->age_max = 0.1;
 }
 
 XimeaROSCam::~XimeaROSCam() {
@@ -63,7 +70,7 @@ XimeaROSCam::~XimeaROSCam() {
         // Close camera device
         xiCloseDevice(this->xi_h_);
         this->xi_h_ = NULL;
-        
+
         ROS_INFO_STREAM("Closed device: " << this->cam_serialno_);
     }
     ROS_INFO("ximea_ros_cam node shutdown complete.");
@@ -83,6 +90,9 @@ void XimeaROSCam::onInit() {
 
     // Camera initialization
     this->initCam();
+
+    // Diagnostics
+    this->initDiagnostics();
 
     // Publishers and Subscriptions
     this->initPubs();
@@ -108,6 +118,21 @@ void XimeaROSCam::initNodeHandles() {
 
     // Report end of function
     ROS_INFO("... Node Handles Loaded. ");
+}
+
+void XimeaROSCam::initDiagnostics() {
+    if (this->enable_diagnostics) {
+        this->diag_updater.setHardwareID(this->cam_name_);
+        this->cam_pub_diag =
+            std::make_shared<diagnostic_updater::TopicDiagnostic>(
+                ros::this_node::getNamespace() + "/image_raw",
+                this->diag_updater,
+                diagnostic_updater::FrequencyStatusParam(
+                    &this->frequency_min, &this->frequency_max,
+                    frequency_tolerance, 1.0),
+                diagnostic_updater::TimeStampStatusParam(
+                    this->age_min, this->age_max));
+    }
 }
 
 // initPubs() - initialize the publishers
@@ -138,9 +163,9 @@ void XimeaROSCam::initTimers() {
     // Report start of function
     ROS_INFO("Loading Timers ... ");
 
-    // Load camera polling callback timer ((Ensure that with multiple cameras, 
+    // Load camera polling callback timer ((Ensure that with multiple cameras,
     // each time is about 2 seconds spaced apart)
-    this->xi_open_device_cb_ = this->private_nh_.createTimer(ros::Duration(this->poll_time_), 
+    this->xi_open_device_cb_ = this->private_nh_.createTimer(ros::Duration(this->poll_time_),
         boost::bind(&XimeaROSCam::openDeviceCb, this));
 
     // Load camera frame capture callback timer
@@ -217,6 +242,8 @@ void XimeaROSCam::initCam() {
     ROS_INFO_STREAM("calibration file: " << this->cam_calib_file_);
     this->private_nh_.param("poll_time", this->poll_time_, -1.0f);
     ROS_INFO_STREAM("poll_time_: " << this->poll_time_);
+    this->private_nh_.param("enable_diagnostics", this->enable_diagnostics, false);
+    ROS_INFO_STREAM("enable_diagnostics: " << this->enable_diagnostics);
 
     //      -- apply compressed image parameters (from image_transport) --
     this->private_nh_.param( "image_transport_compressed_format",
@@ -625,8 +652,8 @@ void XimeaROSCam::frameCaptureCb() {
 
         // Was the image retrieval successful?
         if (xi_stat == XI_OK) {
-            ROS_INFO_STREAM_THROTTLE(3, 
-                "Capturing image from Ximea camera serial no: " 
+            ROS_INFO_STREAM_THROTTLE(3,
+                "Capturing image from Ximea camera serial no: "
                 << this->cam_serialno_
                 << ". WxH: "
                 << xi_img.width
@@ -667,6 +694,11 @@ void XimeaROSCam::frameCaptureCb() {
 
                 // Publish image
                 this->cam_pub_.publish(img);
+                if (this->enable_diagnostics) {
+                    cam_pub_diag->tick(timestamp);
+                    // this->cam_diag_pub->publish(img);
+                    diag_updater.update();
+                }
 
                 // Publish camera calibration info if camera info is loaded
                 if (this->cam_info_loaded_) {

--- a/src/ximea_ros_cam.cpp
+++ b/src/ximea_ros_cam.cpp
@@ -252,7 +252,7 @@ void XimeaROSCam::initCam() {
     this->private_nh_.param("pub_frequency", this->pub_frequency, 10.0);
     ROS_INFO_STREAM("pub_frequency: " << this->pub_frequency);
     this->private_nh_.param("pub_frequency_tolerance",
-        this->pub_frequency_tolerance, 1.0);
+        this->pub_frequency_tolerance, 0.3);
     ROS_INFO_STREAM("pub_frequency_tolerance: " << this->pub_frequency_tolerance);
     this->private_nh_.param("data_age_max", this->age_max, 0.1);
     ROS_INFO_STREAM("data_age_max: " << this->age_max);


### PR DESCRIPTION
Closes #28 

Add a diagnostic updater to monitor publish frequency and data age.

It's been tested once before, but could use one last round of car testing, will add to a test request PR shortly.