### PR TITLE
Added a error check for proper image_directory param setting

### DIFF
--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -205,6 +205,7 @@ class XimeaROSCam : public nodelet::Nodelet {
     std::string image_directory_;
     std::string png_path_;
     std::string bin_path_;
+    
 
     // NODELET HANDLES
     ros::NodeHandle public_nh_;

--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -206,7 +206,6 @@ class XimeaROSCam : public nodelet::Nodelet {
     std::string png_path_;
     std::string bin_path_;
     
-
     // NODELET HANDLES
     ros::NodeHandle public_nh_;
     ros::NodeHandle private_nh_;

--- a/include/ximea_ros_cam/ximea_ros_cam.hpp
+++ b/include/ximea_ros_cam/ximea_ros_cam.hpp
@@ -205,7 +205,7 @@ class XimeaROSCam : public nodelet::Nodelet {
     std::string image_directory_;
     std::string png_path_;
     std::string bin_path_;
-    
+
     // NODELET HANDLES
     ros::NodeHandle public_nh_;
     ros::NodeHandle private_nh_;

--- a/src/ximea_ros_cam.cpp
+++ b/src/ximea_ros_cam.cpp
@@ -209,29 +209,31 @@ void XimeaROSCam::initStorage() {
         if (!boost::filesystem::create_directories(calib_dir))
         {
             // failed to create directory, exit ROS and explain.
-            ROS_INFO_STREAM("ERROR: unable to create directory: " << calib_dir);
+            ROS_INFO_STREAM("ERROR: unable to create directory: " << this->png_path_);
+            ROS_INFO_STREAM("Please make sure that the image_directory "
+                         << "parameter is set to a folder with the proper "
+                         << "permissions in the config file.");
+            ros::shutdown();
+        }
+
+        this->save_trigger_ = false;
+    }
+
+    // directory that holds video stream images
+    if (this->save_disk_) {
+        boost::filesystem::path img_stream_dir = main_dir /
+                                                 (this->cam_name_ + "/stream/");
+        this->bin_path_ = img_stream_dir.string();
+        if (!boost::filesystem::create_directories(img_stream_dir))
+        {
+            // failed to create directory, exit ROS and explain.
+            ROS_INFO_STREAM("ERROR: unable to create directory: " << this->bin_path_);
             ROS_INFO_STREAM("Please make sure that the image_directory "
                          << "parameter is set to a folder with the proper "
                          << "permissions in the config file.");
             ros::shutdown();
         }
     }
-
-    // directory that holds video stream images
-    boost::filesystem::path img_stream_dir = main_dir /
-                                             (this->cam_name_ + "/stream/");
-    this->bin_path_ = img_stream_dir.string();
-    if (!boost::filesystem::create_directories(img_stream_dir))
-    {
-        // failed to create directory, exit ROS and explain.
-        ROS_INFO_STREAM("ERROR: unable to create directory: " << img_stream_dir);
-        ROS_INFO_STREAM("Please make sure that the image_directory "
-                     << "parameter is set to a folder with the proper "
-                     << "permissions in the config file.");
-        ros::shutdown();
-    }
-
-    this->save_trigger_ = false;
 
     ROS_INFO("Image Storage Loaded.");
 }

--- a/src/ximea_ros_cam.cpp
+++ b/src/ximea_ros_cam.cpp
@@ -206,14 +206,30 @@ void XimeaROSCam::initStorage() {
         boost::filesystem::path calib_dir = main_dir /
                                             (this->cam_name_ + "/calib/");
         this->png_path_ = calib_dir.string();
-        boost::filesystem::create_directories(calib_dir);
+        if (!boost::filesystem::create_directories(calib_dir))
+        {
+            // failed to create directory, exit ROS and explain.
+            ROS_INFO_STREAM("ERROR: unable to create directory: " << calib_dir);
+            ROS_INFO_STREAM("Please make sure that the image_directory "
+                         << "parameter is set to a folder with the proper "
+                         << "permissions in the config file.");
+            ros::shutdown();
+        }
     }
 
     // directory that holds video stream images
     boost::filesystem::path img_stream_dir = main_dir /
                                              (this->cam_name_ + "/stream/");
     this->bin_path_ = img_stream_dir.string();
-    boost::filesystem::create_directories(img_stream_dir);
+    if (!boost::filesystem::create_directories(img_stream_dir))
+    {
+        // failed to create directory, exit ROS and explain.
+        ROS_INFO_STREAM("ERROR: unable to create directory: " << img_stream_dir);
+        ROS_INFO_STREAM("Please make sure that the image_directory "
+                     << "parameter is set to a folder with the proper "
+                     << "permissions in the config file.");
+        ros::shutdown();
+    }
 
     this->save_trigger_ = false;
 


### PR DESCRIPTION
Closes #31 

When setting the `image_directory` parameter, usually when it is set to an invalid directory or a directory that the user has no write permissions to, the ximea camera node will exit without explaining why. Here is a way to make sure the user can see why.